### PR TITLE
Fix module imports for scaling functions

### DIFF
--- a/visualizations/scaling/color_scaling.js
+++ b/visualizations/scaling/color_scaling.js
@@ -1,1 +1,3 @@
-export { applyColorScaling } from '../graph_UI/graph_option/scaling/color/color_gradient.js';
+// Re-export the color scaling function used by visualization modules
+// Corrected relative path to the shared color gradient implementation
+export { applyColorScaling } from '../../graph_UI/graph_option/scaling/color/color_gradient.js';

--- a/visualizations/scaling/size_scaling.js
+++ b/visualizations/scaling/size_scaling.js
@@ -1,1 +1,3 @@
-export { applyScaling } from '../graph_UI/graph_option/scaling/size/size_scaling_functions.js';
+// Re-export the size scaling utilities used across visualization modules
+// Corrected the relative import path to reference the shared functions
+export { applyScaling } from '../../graph_UI/graph_option/scaling/size/size_scaling_functions.js';


### PR DESCRIPTION
## Summary
- fix relative paths for color and size scaling modules

## Testing
- `node --check visualizations/scaling/color_scaling.js`
- `node --check visualizations/scaling/size_scaling.js`
- `node --check visualizations/chart_factory.js`


------
https://chatgpt.com/codex/tasks/task_e_685d8409cc148331b3b040d31bc4f456